### PR TITLE
Add individual work page

### DIFF
--- a/_profiles/work.html
+++ b/_profiles/work.html
@@ -1,0 +1,48 @@
+---
+#
+# The human-friendly name of the profile. Whenever you're asked for the profile
+# ID, it refers to the name of the profile file — in this case, "default".
+#
+name: "Work"
+
+#
+# The default profile will be the one shown when accessing the root URL of your
+# SpeedTracker site.
+#
+default: false
+
+#
+# If you want tests to be repeated automatically, you can an interval (in hours)
+# with a minimum value of 12, as only two scheduled tests per day are allowed.
+# To disabled repeated tests, simply remove this property from the profile.
+#
+interval: 12
+
+#
+# WebPageTest test parameters
+#
+parameters:
+  connectivity: "Cable"
+  location: "London_EC2"
+  runs: 1
+  url: "https://wellcomecollection.org/works/v9g6hmpw?query=david&cohort=platformTeam"
+
+#
+# Performance budgets are defined with a metric id, a max/min allowed value
+# (in milliseconds), and done or multiple alerts — referenced by the ids defined
+# in the main config — to be triggered when a budget is overrun.
+#
+# For a list of metrics, check:
+#
+# https://github.com/speedtracker/speedtracker-api/blob/master/lib/SpeedTracker.js#L18-L37
+#
+budgets:
+  -
+    metric: firstPaint
+    max: 1500
+    alerts: ["slackAlert"]
+  -
+    metric: SpeedIndex
+    max: 2500
+    alerts: ["slackAlert"]
+---

--- a/_profiles/work.html
+++ b/_profiles/work.html
@@ -29,7 +29,7 @@ parameters:
 
 #
 # Performance budgets are defined with a metric id, a max/min allowed value
-# (in milliseconds), and done or multiple alerts — referenced by the ids defined
+# (in milliseconds), and one or multiple alerts — referenced by the ids defined
 # in the main config — to be triggered when a budget is overrun.
 #
 # For a list of metrics, check:


### PR DESCRIPTION
Lets us track individual work page performance (sadly too late to compare pre/post JSX conversion).